### PR TITLE
Add LocalDate filters for dateFrom and dateTo in event search

### DIFF
--- a/src/main/java/com/calendarapi/lbprojektm165calendarapi/controller/EventController.java
+++ b/src/main/java/com/calendarapi/lbprojektm165calendarapi/controller/EventController.java
@@ -85,7 +85,9 @@ EventController {
             @RequestParam(required = false) String from,
             @RequestParam(required = false) String to,
             @RequestParam(required = false) String tag,
-            @RequestParam(required = false) String titleContains  // 👈 NEU
+            @RequestParam(required = false) String titleContains,
+            @RequestParam(required = false) String dateFrom,
+            @RequestParam(required = false) String dateTo
     ) {
         FilterDto filter = new FilterDto();
         filter.setWeekday(weekday);
@@ -94,6 +96,8 @@ EventController {
         filter.setTo(to);
         filter.setTag(tag);
         filter.setTitleContains(titleContains);
+        filter.setDateFrom(dateFrom);
+        filter.setDateTo(dateTo);
         return eventService.listEvents(filter);
     }
 }

--- a/src/main/java/com/calendarapi/lbprojektm165calendarapi/dto/FilterDto.java
+++ b/src/main/java/com/calendarapi/lbprojektm165calendarapi/dto/FilterDto.java
@@ -106,9 +106,11 @@ public class FilterDto {
     public String getTitleContains() {
         return titleContains;
     }
+
     public LocalDate getDateFrom() {
         return dateFrom;
     }
+
     public LocalDate getDateTo() {
         return dateTo;
     }


### PR DESCRIPTION
- Erweiterung von FilterDto um dateFrom/dateTo als LocalDate
- Ermöglicht Abfragen wie /api/events?dateFrom=2025-08-01&dateTo=2025-08-31
- Anpassung des Repositories zur Filterung nach Zeitspanne